### PR TITLE
feat(templates): add PR and ISSUE templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,49 @@
+### Issue
+
+- [ ] This is a bug report.
+- [ ] This is a feature request.
+
+Please fill out the appropriate template below and remove the unused template.
+
+### Archiving
+
+- [ ] Did you check for similar existing issues?
+
+### Description
+
+[Description of the bug or feature.]  
+[Include images where appropriate]
+
+## Bug Report Details :warning::bug: 
+### Steps to Reproduce
+
+- [ ] Is the bug reproducible?
+
+1. [First Step]
+2. [Second Step]
+3. [Include images]
+4. [and so on...]
+
+**Expected behavior:** [What you expected to happen]
+
+**Actual behavior:** [What actually happened]
+
+
+## Feature Request Details :star:
+### Links to feature design doc, conversations, mockups, etc.
+[Provide links or documents here for context.]
+
+### Stakeholders
+[Please reference the stakeholders for this feature]
+
+### Functional Requirements:
+[What does the feature need to do?]  
+[Describe system behaviors using [ubiquitous language](http://ddd.fed.wiki.org/view/ubiquitous-language) and [intention revealing interfaces](http://ddd.fed.wiki.org/view/intention-revealing-interfaces).]  
+
+### Non-functional Requirements:
+[What constraints exist for this feature?]  
+[All constraints must be quantifiable.]
+
+### Acceptance Criteria:
+[What needs to happen functionally for this work to pass review?]  
+[Usually a combination of FRs and NFRs as test cases written in plain text.]  

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,20 +1,17 @@
-### Issue
+### Is this issue a "Bug Report :warning::bug:"  or a "Feature Request :star:" ?
 
-- [ ] This is a bug report.
-- [ ] This is a feature request.
+- [ ] Please check for similar existing issues before submitting.
+- [ ] Please fill out the appropriate template below and remove the unused template.
+- [ ] Please tag your issue with either https://github.com/nasa-gcn/.github/labels/bug or https://github.com/nasa-gcn/.github/labels/enhancement
+- [ ] Please remove this section before submitting.
 
-Please fill out the appropriate template below and remove the unused template.
-
-### Archiving
-
-- [ ] Did you check for similar existing issues?
-
-### Description
-
-[Description of the bug or feature.]  
-[Include images where appropriate]
 
 ## Bug Report Details :warning::bug: 
+### Description
+
+[Description of the bug]  
+[Include images where appropriate]
+
 ### Steps to Reproduce
 
 - [ ] Is the bug reproducible?
@@ -30,20 +27,25 @@ Please fill out the appropriate template below and remove the unused template.
 
 
 ## Feature Request Details :star:
+### Description
+
+[Description of the feature]  
+[Include images where appropriate]
+
 ### Links to feature design doc, conversations, mockups, etc.
 [Provide links or documents here for context.]
 
 ### Stakeholders
 [Please reference the stakeholders for this feature]
 
-### Functional Requirements:
+### Functional Requirements
 [What does the feature need to do?]  
 [Describe system behaviors using [ubiquitous language](http://ddd.fed.wiki.org/view/ubiquitous-language) and [intention revealing interfaces](http://ddd.fed.wiki.org/view/intention-revealing-interfaces).]  
 
-### Non-functional Requirements:
+### Non-functional Requirements
 [What constraints exist for this feature?]  
 [All constraints must be quantifiable.]
 
-### Acceptance Criteria:
+### Acceptance Criteria
 [What needs to happen functionally for this work to pass review?]  
 [Usually a combination of FRs and NFRs as test cases written in plain text.]  

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+### IMPORTANT: Please do not create a Pull Request without creating an issue first.
+
+### Title
+Please remove this section and [use conventional commits structure](https://www.conventionalcommits.org/en/v1.0.0/) for PR titles.  
+E.g. feat(api): add Foo to Bar
+
+### Description
+A one to two sentence summary of the PR for easy digestion, must be different and more descriptive than title. Combination of title and description should summarize the issue + solution.
+
+### Reviewers
+List all reviewers here and briefly describe why they are invited for review.
+By default, the PR author should merge once the reviewers have had a chance to review.
+If you have a different preference or cannot merge after review for some other constraint, leave a note about it here.
+
+### Changes
+List your changes
+
+### Acceptance Criteria
+What needs to happen functionally for this work to pass review?  
+
+### Related Issue(s)
+Remove this line and link your issue here: Issue #1234 - Add Foo to Bar.  
+
+### Testing
+Add how you tested this PR AND add steps for testing this PR.  
+Be specific and include images when appropriate.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -13,13 +13,13 @@ By default, the PR author should merge once the reviewers have had a chance to r
 If you have a different preference or cannot merge after review for some other constraint, leave a note about it here.
 
 ### Changes
-List your changes
+List your changes in detail
 
 ### Acceptance Criteria
 What needs to happen functionally for this work to pass review?  
 
 ### Related Issue(s)
-Remove this line and link your issue here: Issue #1234 - Add Foo to Bar.  
+Resolves [Paste Issue URL here]
 
 ### Testing
 Add how you tested this PR AND add steps for testing this PR.  


### PR DESCRIPTION
### Description
New github Issues and PR templates are available and will be enabled automatically following merging this PR in all projects under the https://github.com/nasa-gcn organization

### Reviewers
@Courey @dakota002 @swyatt7 @jak574 @lpsinger @Kirill-Vorobyev
Please review the templates for correctness and grammar. 
Provide any suggestions to the templates so we can collaboratively iterate on their design.
Add any additional reviewers to this PR for context as you see fit.
Once we reach quorum on this PR with majority of stakeholders approving, we can merge and iterate on these templates as follow up issues.

### Changes
- Added ISSUE_TEMPLATE.md
- Added PULL_REQUEST_TEMPLATE.md

### Acceptance Criteria
1. When a user creates an issue, the issue template should appear automatically.
2. When a user submits a Pull Request, the PR template should appear automatically.

Note: currently not possible to test because this initial issue/PR will add the templates.

### Related Issue(s)
Fixes https://github.com/nasa-gcn/.github/issues/6 

### Testing
1. Manually pasted and filled out the template for this PR and associated issue linked above.