### PR TITLE
Add issue templates to automatically assign labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,3 @@
+name: Bug Report
+labels:
+  - bug

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,3 @@
+name: Enhancement or Feature Request
+labels:
+  - enhancement


### PR DESCRIPTION
Assign the "bug" or "feature" label to issues automatically as a result of selecting an issue template from a menu.

The templates themselves are currently empty.