### PR TITLE
Configure issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Frequently Asked Questions
+    url: https://gcn.nasa.gov/docs/faq
+    about: Check here for answers to common questions.
+  - name: User Support
+    url: https://gcn.nasa.gov/docs/faq
+    about: Submit user support questions (such as questions about your account) here.


### PR DESCRIPTION
The template chooser is not showing up yet. Try adding a template chooser config file.

See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser.