### PR TITLE
Add minimial, non-blank issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,20 @@
+---
+name: Bug Report
+labels: bug
+---
+
+<!--
+Note: this text is a comment, and won't show up in the issue.
+Please search existing issues to check if your issue has already been recorded.
+Fill out the sections below. Delete any sections that are not relevant.
+-->
+
+# Current behavior
+
+# Expected behavior
+
+# Steps to reproduce
+
+# Environment
+
+<!-- e.g. browser version and operating system -->

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,3 +1,0 @@
-name: Bug Report
-labels:
-  - bug

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,14 @@
+---
+name: Enhancement or Feature Request
+labels: enhancement
+---
+
+<!--
+Note: this text is a comment, and won't show up in the issue.
+Please search existing issues to check if your issue has already been recorded.
+Fill out the sections below. Delete any sections that are not relevant.
+-->
+
+# Description
+
+# Acceptance criteria

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,3 +1,0 @@
-name: Enhancement or Feature Request
-labels:
-  - enhancement


### PR DESCRIPTION
The issue templates are not showing up in the template chooser because the bodies are blank. Add minimal, non-blank templates.

Switch from forms to Markdown templates, because Markdown templates allow the user to delete irrelevant sections.