### PR TITLE
Add "about" field to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,5 +1,6 @@
 ---
 name: Bug Report
+about: Report a bug or defect
 labels: bug
 ---
 

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,5 +1,6 @@
 ---
 name: Enhancement or Feature Request
+about: Suggest an enhancement or a new feature
 labels: enhancement
 ---
 


### PR DESCRIPTION
The issue templates are still not showing up. GitHub shows the error message: "There is a problem with this template. About can't be blank."