### PR TITLE
Allow callers to customize CLI options for test runner

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -2,6 +2,12 @@ name: Build and test Node.js
 
 on:
   workflow_call:
+    inputs:
+      test-options:
+        description: Arguments to pass to test runner
+        default: --coverage
+        required: false
+        type: string
 
 jobs:
   matrix:
@@ -38,6 +44,6 @@ jobs:
         # See https://prettier.io/docs/en/options.html#end-of-line
         if: ${{ runner.os != 'Windows' }}
       - name: Run unit tests
-        run: npm test --if-present -- --coverage
+        run: npm test --if-present -- ${{ inputs.test-options }}
       - name: Upload to Codecov.io
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Some projects use Jest for test coverage and some use the builtin Node.js test runner. The two frameworks accept different CLI options. Allow the calling workflow to customize the CLI options for the test runner.

See https://github.com/nasa-gcn/architect-plugin-search/pull/45.