### PR TITLE
Move "Add New GCN Notice Producer" to org scope

### DIFF
--- a/.github/ISSUE_TEMPLATE/producer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/producer-onboarding.md
@@ -1,0 +1,27 @@
+---
+name: Add New GCN Notice Producer
+about: Checklist to add a new producer of GCN Notices
+labels: new-producer
+---
+
+<!--
+Note: this text is a comment, and won't show up in the issue.
+Please search existing issues to check if your issue has already been recorded.
+Fill out the sections below. Delete any sections that are not relevant.
+-->
+
+# Description
+
+Steps for onboarding new notices from the #### mission/observatory/instrument.
+Documentation: https://gcn.nasa.gov/docs/notices/producers
+Unified Schema: https://gcn.nasa.gov/docs/notices/schema
+
+# Acceptance criteria
+
+- [ ] create topics/acls
+- [ ] JSON schema
+- [ ] mission page
+- [ ] add to quickstart
+- [ ] announcement
+
+# Mission contact people


### PR DESCRIPTION
According to https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#about-default-community-health-files:

> If a repository has any files in its own .github/ISSUE_TEMPLATE folder, including issue templates or a config.yml file, none of the contents of the default .github/ISSUE_TEMPLATE folder will be used.

See https://github.com/nasa-gcn/gcn.nasa.gov/issues/2658.