### PR TITLE
add details to producer onboarding issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/producer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/producer-onboarding.md
@@ -18,7 +18,7 @@ Unified Schema: https://gcn.nasa.gov/docs/notices/schema
 
 # Acceptance criteria
 
-- [ ] create [topics/acls](https://gcn.nasa.gov/docs/notices/producers) (GCN Team)
+- [ ] create [topics/ACLs](https://gcn.nasa.gov/docs/notices/producers) (GCN Team)
 - [ ] finalize [JSON schema](https://gcn.nasa.gov/docs/notices/schema) (Producers)
 - [ ] add/update [producer mission page](https://gcn.nasa.gov/missions) (Producers)
 - [ ] update [mission page table](https://gcn.nasa.gov/missions) (GCN Team)

--- a/.github/ISSUE_TEMPLATE/producer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/producer-onboarding.md
@@ -18,10 +18,12 @@ Unified Schema: https://gcn.nasa.gov/docs/notices/schema
 
 # Acceptance criteria
 
-- [ ] create topics/acls
-- [ ] JSON schema
-- [ ] mission page
-- [ ] add to quickstart
-- [ ] announcement
+- [ ] create [topics/acls](https://gcn.nasa.gov/docs/notices/producers) (GCN Team)
+- [ ] finalize [JSON schema](https://gcn.nasa.gov/docs/notices/schema) (Producers)
+- [ ] add/update [producer mission page](https://gcn.nasa.gov/missions) (Producers)
+- [ ] update [mission page table](https://gcn.nasa.gov/missions) (GCN Team)
+- [ ] add to [quickstart](https://gcn.nasa.gov/quickstart) (GCN Team)
+- [ ] remove [feature flag](https://gcn.nasa.gov/docs/contributing/feature-flags) (GCN Team)
+- [ ] post and distribute [announcement](https://gcn.nasa.gov/news) (GCN Team)
 
 # Mission contact people


### PR DESCRIPTION
# Description
Adds steps and details to producer onboarding tracking issue template.  These new steps are things we've been finding that are part of the onboarding process, so we should track them.

# Related Issues
Note that this refers to the mission table, which is under review as [#2884](https://github.com/nasa-gcn/gcn.nasa.gov/pull/2884).