### PR TITLE
added items to producer onboarding issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/producer-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/producer-onboarding.md
@@ -19,10 +19,12 @@ Unified Schema: https://gcn.nasa.gov/docs/notices/schema
 # Acceptance criteria
 
 - [ ] create [topics/ACLs](https://gcn.nasa.gov/docs/notices/producers) (GCN Team)
+- [ ] add producer POC to producers git team  (GCN Team)
 - [ ] finalize [JSON schema](https://gcn.nasa.gov/docs/notices/schema) (Producers)
 - [ ] add/update [producer mission page](https://gcn.nasa.gov/missions) (Producers)
 - [ ] update [mission page table](https://gcn.nasa.gov/missions) (GCN Team)
 - [ ] add to [quickstart](https://gcn.nasa.gov/quickstart) (GCN Team)
+- [ ] test and validate production notices (Producers + GCN Team)
 - [ ] remove [feature flag](https://gcn.nasa.gov/docs/contributing/feature-flags) (GCN Team)
 - [ ] post and distribute [announcement](https://gcn.nasa.gov/news) (GCN Team)
 


### PR DESCRIPTION
# Description
As we're defining and documenting the Notice producer onboarding procedure, we need to add items to the producer-onboarding issue template.

# Related Issue(s)
Resolves https://github.com/nasa-gcn/gcn.nasa.gov/issues/3067 and partially addresses https://github.com/nasa-gcn/gcn.nasa.gov/issues/3066