### PR TITLE
Hide PR guidance behind comments

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,15 +1,15 @@
 <!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->
 
 # Description
-Please include a one to two sentence description that summarizes the issue and your solution.
+<!--  Please include a one to two sentence description that summarizes the issue and your solution. -->
+
 
 # Related Issue(s)
-Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
-
+<!-- Use Github keywords to link your PR to the related Issue(s). For more information on Github keywords please visit [Github's documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
 Example:
+`Resolves #100` -->
 
-`Resolves #100`
 
 # Testing
-Describe how you tested this PR. Include step by step instructions for others to test this PR.
-Be detailed and include images where appropriate.
+<!-- Describe how you tested this PR. Include step by step instructions for others to test this PR.
+Be detailed and include images where appropriate. -->


### PR DESCRIPTION
<!-- IMPORTANT!!! Aside from typographical corrections and minor changes, please consider creating an Issue before making a Pull Request. -->

# Description
Currently, the PR template includes guidance text that has to be deleted prior to filling out the PR. This hides the PR guidance behind comments so it won't be necessary to delete them upon initiating every PR.

# Related Issue(s)
Resolves nasa-gcn/gcn.nasa.gov/issues/3165

# Testing
n/a
